### PR TITLE
Move verify pipeline to public infrastructure

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -10,7 +10,8 @@ github:
      - "Version: Bump Minor"
 
 pipelines:
-  - verify
+  - verify:
+      public: true
 
 merge_actions:
   - built_in:bump_version:


### PR DESCRIPTION
I'll address failing tests in another PR. This is just to migrate the pipeline so it's publically available. 

Signed-off-by: Tom Duffield <tom@chef.io>