### PR TITLE
Add support for starting with devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,15 @@ Will stop the VM, set memory size, and then execute commands you've specified.
 
 Example: `32`
 
+## Anka Start ---
+
+### `start-devices` (optional)
+
+Will stop the VM, then start it with the USB device(s).
+
+- Input should be the USB device ID/Location and should already be claimed.
+
+Example: `341835776`
 
 ## License
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-version: '2'
+version: '3.4'
 services:
   tests:
     image: buildkite/plugin-tester
     volumes:
-      - ".:/plugin:ro"
+      - ".:/plugin"

--- a/hooks/command
+++ b/hooks/command
@@ -85,7 +85,8 @@ lock_file disable # If two pulls or a clone and a pull happen on the same host, 
 # Handle modifications to CPU/RAM/etc
 BUILDKITE_PLUGIN_ANKA_MODIFY_CPU=$(plugin_read_list MODIFY_CPU)
 BUILDKITE_PLUGIN_ANKA_MODIFY_RAM=$(plugin_read_list MODIFY_RAM)
-if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_CPU}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}" ]]; then
+BUILDKITE_PLUGIN_ANKA_START_DEVICES=$(plugin_read_list START_DEVICES)
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_CPU}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_START_DEVICES}" ]]; then
   echo "--- :anka: Ensuring $job_image_name is stopped"
   FORCED=${FORCED:-false} # Used for bats triggering of ops
   stop_ops=()
@@ -106,6 +107,17 @@ if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}" ]]; then
   echo "--- :anka: Modifying RAM to ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G"
   # shellcheck disable=SC2086
   plugin_prompt_and_run anka modify $job_image_name set ram ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G
+fi
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_START_DEVICES}" ]]; then
+  start_devices=()
+  while IFS='' read -r line; do start_devices+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_START_DEVICES"
+  option=""
+  for device in "${start_devices[@]:+${start_devices[@]}}"; do
+   option+="-d ${device} "
+  done
+  echo "--- :anka: Starting VM with ${option}"
+  # shellcheck disable=SC2086
+  plugin_prompt_and_run anka start $option $job_image_name
 fi
 
 ###############################################################

--- a/plugin.yml
+++ b/plugin.yml
@@ -41,6 +41,8 @@ configuration:
       type: integer
     modify-ram:
       type: integer
+    start-devices:
+      type: array
   required:
     - vm-name
 additionalProperties: false


### PR DESCRIPTION
This is my first attempt to add support for starting a VM with physical devices.

    1. I added a new key in the yaml: `start-devices` which accepts an array of device names/IDs
    2. I added a check that if `start-devices is present to ensure like the modify VM commands to stop/suspend the VM
    3. I added a step after the VM is stopped to start it with the `-d <NAME> -d <NAME..` option(s)
    4. I added a test trying to verify this.

However, my test is failing and I am really not sure why. I want to share for feedback on how to fix.
