### PR TITLE
Failover Registry list + anka run pre command execute sleep

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ Commands to run on the HOST machine AFTER any guest/anka run commands. Useful if
 
 Example: `buildkite-agent artifact upload "build.tar.gz"`
 
+### `failover-registries` (optional)
+
+Should the default registry not be available, the failover registries you specify will be used. It will go through each in the list and use the first available.
+
+Example:
+```
+    plugins:
+    - chef/anka#v0.5.4:
+        failover-registries:
+          - 'registry_1'
+          - 'registry_2'
+          - 'registry_3'
+```
+
+### `pre-execute-sleep` (optional)
+
+Will execute a sleep with the value you specify within anka run and before the first command. Useful if you need to ensure that certain processes and networking are fully functional before running your commands in the VM.
+
+Example: `5` (seconds)
+
 ## Anka Modify ---
 
 ### `modify-cpu` (optional)

--- a/hooks/command
+++ b/hooks/command
@@ -38,7 +38,7 @@ if ( ! anka $ANKA_DEBUG list "$(plugin_read_config VM_NAME)" ) || [[ $(plugin_re
   fi
   echo "--- :anka: Pulling $(plugin_read_config VM_NAME) from Anka Registry"
   # shellcheck disable=SC2086
-  plugin_prompt_and_run anka $ANKA_DEBUG registry pull "${pull_args[@]:+${pull_args[@]}}" "$(plugin_read_config VM_NAME)" # ${pull_args[@]:+${pull_args[@]}}: pull_args[@]: unbound variable : https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
+  plugin_prompt_and_run anka $ANKA_DEBUG registry $FAILOVER_REGISTRY pull "${pull_args[@]:+${pull_args[@]}}" "$(plugin_read_config VM_NAME)" # ${pull_args[@]:+${pull_args[@]}}: pull_args[@]: unbound variable : https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
 else
   echo ":anka: $(plugin_read_config VM_NAME) is already present on the host"
 fi
@@ -133,7 +133,7 @@ bash_ops+=("-c") # Needed, don't remove
 ##########
 # ANKA RUN
 commands=()
-while IFS='' read -r line; do commands+=("$line"); done <<< "$BUILDKITE_COMMAND"
+while IFS='' read -r line; do commands+=("${PRE_EXECUTE_SLEEP}$line"); done <<< "$BUILDKITE_COMMAND"
 for command in "${commands[@]:-}"; do
   echo "+++ Executing $command in $job_image_name"
   # shellcheck disable=SC2086

--- a/plugin.yml
+++ b/plugin.yml
@@ -37,6 +37,10 @@ configuration:
       type: array
     post-commands:
       type: array
+    failover-registries:
+      type: array
+    pre-execute-sleep:
+      type: integer
     modify-cpu:
       type: integer
     modify-ram:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description

1. There is a networking bug in 2.1 anka build software that requires a sleep of a few seconds before doing a git clone. Also, I've had a situation where I need to sleep before each command to ensure downstream/triggered services update properly before running the next command. The `pre-execute-sleep` is designed to specify the sleep time to use before any anka run command.

2. I've split my anka fleet into two identical registries (for blue/green deployments and updates of anka software). This requires failover logic to switch nodes using one, to another registry should their default go down.

- I've added complete tests for both.
- I've also tested this live in our pipelines and things are working as expected.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
