### PR TITLE
Fix for pre/post-commands to support chaining with &&, ||, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,23 @@ Example: `true`
 
 Commands to run on the HOST machine BEFORE any guest/anka run commands. Useful if you need to download buildkite artifacts into the current working directory from a previous step. This can destroy your host. Be very careful what you do with it.
 
-Example: `buildkite-agent artifact download "build.tar.gz" . --step ":aws: Amazon Linux 1 Build"`
+- Be sure to double escape variables you don't want eval to try and interpolate too soon.
+
+Example:
+```
+    plugins:
+    - chef/anka . . .
+        pre-commands:
+          - 'echo 123 && echo 456'
+          - 'buildkite-agent artifact download "build.tar.gz" . --step ":aws: Amazon Linux 1 Build"'
+          - 'echo \\$variableOnTheHost'
+```
 
 ### `post-commands` (optional) (DANGEROUS)
 
 Commands to run on the HOST machine AFTER any guest/anka run commands. Useful if you need to upload artifacts created in the build/test process. This can destroy your host. Be very careful what you do with it.
 
-Example: `buildkite-agent artifact upload "build.tar.gz"`
+Example: A list, similar to pre-commands.
 
 ### `failover-registries` (optional)
 

--- a/hooks/command
+++ b/hooks/command
@@ -16,8 +16,13 @@ if [[ -n "${BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS}" ]]; then
   while IFS='' read -r line; do host_commands+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS"
   for command in "${host_commands[@]:+${host_commands[@]}}"; do
     echo "--- :anka: Executing ${command} on host"
+    if [[ $(plugin_read_config DEBUG "false") =~ (true|on|1) ]] ; then
+      echo -ne '\033[90m$\033[0m' >&2
+      printf " %q" "eval \"$command\"" >&2
+      echo >&2
+    fi
     # shellcheck disable=SC2086
-    plugin_prompt_and_run $command
+    eval "$command"
   done
 fi
 
@@ -148,7 +153,12 @@ if [[ -n "${BUILDKITE_PLUGIN_ANKA_POST_COMMANDS}" ]]; then
   while IFS='' read -r line; do host_commands+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_POST_COMMANDS"
   for command in "${host_commands[@]:+${host_commands[@]}}"; do
     echo "--- :anka: Executing ${command} on host"
+    if [[ $(plugin_read_config DEBUG "false") =~ (true|on|1) ]] ; then
+      echo -ne '\033[90m$\033[0m' >&2
+      printf " %q" "eval \"$command\"" >&2
+      echo >&2
+    fi
     # shellcheck disable=SC2086
-    plugin_prompt_and_run $command
+    eval "$command"
   done
 fi

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -328,12 +328,14 @@ env"
   export BUILDKITE_JOB_ID="UUID"
   export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
   export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS="buildkite-agent artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 1 Build\"
+  export BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS="echo 123 && echo 456
+echo got 123 && echo \" got 456 \"
+buildkite-agent artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 1 Build\"
 buildkite-agent artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 2 Build\""
 
   stub buildkite-agent \
-    'artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 1 Build\" : echo downloaded artifact 1' \
-    'artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 2 Build\" : echo downloaded artifact 2'
+    'artifact download "build.tar.gz" . --step ":aws: Amazon Linux 1 Build" : echo downloaded artifact 1' \
+    'artifact download "build.tar.gz" . --step ":aws: Amazon Linux 2 Build" : echo downloaded artifact 2'
 
   stub anka \
     "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
@@ -343,11 +345,14 @@ buildkite-agent artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux
   run $PWD/hooks/command
 
   assert_success
+  assert_output --partial "123"
+  assert_output --partial "456"
+  assert_output --partial "got 123"
+  assert_output --partial " got 456"
   assert_output --partial "downloaded artifact 1"
   assert_output --partial "downloaded artifact 2"
   assert_output --partial "cloned vm in anka"
   assert_output --partial "ran ls command in anka"
-  # assert_output --partial "echo downloaded artifact2"
 
   unstub anka
   unstub buildkite-agent
@@ -394,12 +399,14 @@ iphone2"
   export BUILDKITE_JOB_ID="UUID"
   export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
   export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_POST_COMMANDS="buildkite-agent artifact upload \"build.tar.gz\"
+  export BUILDKITE_PLUGIN_ANKA_POST_COMMANDS="echo 123 && echo 456
+echo got 123 && echo \" got 456 \"
+buildkite-agent artifact upload \"build.tar.gz\"
 buildkite-agent artifact upload \"build.tar.gz\""
 
   stub buildkite-agent \
-    'artifact upload \"build.tar.gz\" : echo upload artifact 1' \
-    'artifact upload \"build.tar.gz\" : echo upload artifact 2'
+    'artifact upload "build.tar.gz" : echo upload artifact 1' \
+    'artifact upload "build.tar.gz" : echo upload artifact 2'
 
   stub anka \
     "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
@@ -409,6 +416,10 @@ buildkite-agent artifact upload \"build.tar.gz\""
   run $PWD/hooks/command
 
   assert_success
+  assert_output --partial "123"
+  assert_output --partial "456"
+  assert_output --partial "got 123"
+  assert_output --partial " got 456"
   assert_output --partial "upload artifact 1"
   assert_output --partial "upload artifact 2"
   assert_output --partial "cloned vm in anka"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

We're running a complex oneliner in pre-commands and it doesn't seem to be working. Further investigation shows that the `&&` we're using is executing as `\&\&` and not actually chaining.

This is due to the plugin_prompt_and_run, so I've set up an `eval "$command"` to prevent this.

I've tested this in my own pipeline and it works great.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
