### PR TITLE
PRE_EXECUTE_PING_SLEEP

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ Will execute a sleep with the value you specify within anka run and before the f
 
 Example: `5` (seconds)
 
+### `pre-execute-ping-sleep` (optional)
+
+Will execute a ping while loop sleep with the ip you specify before any commands run in the VM. Useful if you need to ensure that certain processes and networking are fully functional before running your commands in the VM.
+
+Example: `8.8.8.8`
+
 ## Anka Modify ---
 
 ### `modify-cpu` (optional)

--- a/hooks/command
+++ b/hooks/command
@@ -138,7 +138,7 @@ bash_ops+=("-c") # Needed, don't remove
 ##########
 # ANKA RUN
 commands=()
-while IFS='' read -r line; do commands+=("${PRE_EXECUTE_SLEEP}$line"); done <<< "$BUILDKITE_COMMAND"
+while IFS='' read -r line; do commands+=("${PRE_EXECUTE_SLEEP}${PRE_EXECUTE_PING_SLEEP}$line"); done <<< "$BUILDKITE_COMMAND"
 for command in "${commands[@]:-}"; do
   echo "+++ Executing $command in $job_image_name"
   # shellcheck disable=SC2086

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -84,7 +84,7 @@ export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP=$(plugin_read_config PRE_EXECUTE_
 # while-Sleep (useful for networking init issues; similar to the PRE_EXECUTE_SLEEP)
 export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP=$(plugin_read_config PRE_EXECUTE_PING_SLEEP)
 export PRE_EXECUTE_PING_SLEEP=
-[[ ! -z $BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP ]] && export PRE_EXECUTE_PING_SLEEP="while ! ping -c1 $BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP; do sleep 1; done;"
+[[ ! -z $BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP ]] && export PRE_EXECUTE_PING_SLEEP="while ! ping -c1 $BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP | grep -v '\---'; do sleep 1; done;"
 
 ###################
 # Registry Failover

--- a/lib/shared.bash
+++ b/lib/shared.bash
@@ -80,6 +80,12 @@ $BUILDKITE_PLUGIN_ANKA_ANKA_DEBUG && export ANKA_DEBUG="--debug" || export ANKA_
 export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP=$(plugin_read_config PRE_EXECUTE_SLEEP false)
 [[ $BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP != false ]] && export PRE_EXECUTE_SLEEP="sleep $BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP; " || export PRE_EXECUTE_SLEEP=
 
+########################################################
+# while-Sleep (useful for networking init issues; similar to the PRE_EXECUTE_SLEEP)
+export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP=$(plugin_read_config PRE_EXECUTE_PING_SLEEP)
+export PRE_EXECUTE_PING_SLEEP=
+[[ ! -z $BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP ]] && export PRE_EXECUTE_PING_SLEEP="while ! ping -c1 $BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP; do sleep 1; done;"
+
 ###################
 # Registry Failover
 export BUILDKITE_PLUGIN_ANKA_FAILOVER_REGISTRIES=$(plugin_read_list FAILOVER_REGISTRIES)

--- a/plugin.yml
+++ b/plugin.yml
@@ -41,6 +41,8 @@ configuration:
       type: array
     pre-execute-sleep:
       type: integer
+    pre-execute-ping-sleep:
+      type: string
     modify-cpu:
       type: integer
     modify-ram:

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -557,6 +557,46 @@ env"
   unset BUILDKITE_JOB_ID
 }
 
+@test "Run with pre-execute-ping-sleep" {
+  export BUILDKITE_JOB_ID="UUID"
+  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
+  export BUILDKITE_COMMAND="ls -alht
+env"
+  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
+  export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP="8.8.8.8"
+
+  stub anka \
+    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
+    "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
+    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
+    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"while ! ping -c1 ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP}; do sleep 1; done;ls -alht\" : echo ran command in anka" \
+    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"while ! ping -c1 ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP}; do sleep 1; done;env\" : echo ran command in anka"
+
+  run $PWD/hooks/command
+
+  assert_success
+
+  unstub anka
+  unset BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP
+
+  stub anka \
+    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
+    "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
+    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
+    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ran command in anka" \
+    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"env\" : echo ran command in anka"
+
+  run $PWD/hooks/command
+
+  assert_success
+
+  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
+  unset BUILDKITE_COMMAND
+  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
+  unset BUILDKITE_JOB_ID
+}
+
+
 @test "Modify" {
   export BUILDKITE_JOB_ID="UUID"
   export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,7 +3,7 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-# export ANKA_STUB_DEBUG=/dev/tty
+export ANKA_STUB_DEBUG=/dev/tty
 # export BUILDKITE_PLUGIN_ANKA_DEBUG=true
 
 export BUILDKITE_BUILD_URL="https://buildkite.com/repo/name/builds/12034"
@@ -569,8 +569,8 @@ env"
     "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
     "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
     "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"while ! ping -c1 ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP}; do sleep 1; done;ls -alht\" : echo ran command in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"while ! ping -c1 ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP}; do sleep 1; done;env\" : echo ran command in anka"
+    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"while ! ping -c1 ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP} | grep -v '\\---'; do sleep 1; done;ls -alht\" : echo ran command in anka" \
+    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"while ! ping -c1 ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP} | grep -v '\\---'; do sleep 1; done;env\" : echo ran command in anka"
 
   run $PWD/hooks/command
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,7 +3,7 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
-export ANKA_STUB_DEBUG=/dev/tty
+# export ANKA_STUB_DEBUG=/dev/tty
 # export BUILDKITE_PLUGIN_ANKA_DEBUG=true
 
 export BUILDKITE_BUILD_URL="https://buildkite.com/repo/name/builds/12034"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Problem: The wait-network feature doesn't work for us and still allows for a delay which requires a sleep to be specified. 

Solution: Instead of doing a sleep of X seconds, I'm adding a feature to ping an IP and only continue when there is a response from it.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
