### PR TITLE
Added workdir-create so ensure the workdir exists on the host before executing commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ The fully-qualified path of the working directory inside the Anka VM.
 
 Example: `/some/directory`
 
+### `workdir-create` (optional)
+
+Will execute `mkdir -p $WORKDIR` to ensure it exists before executing commands.
+
+Example: `true`
+
 ### `debug` (optional)
 
 Set this to `true` to enable debug output within the plugin.

--- a/hooks/command
+++ b/hooks/command
@@ -125,6 +125,13 @@ if [[ -n "${BUILDKITE_PLUGIN_ANKA_START_DEVICES}" ]]; then
   plugin_prompt_and_run anka start $option $job_image_name
 fi
 
+# Ensure the workdir exists
+# shellcheck disable=SC2086,SC2154,SC2091
+if [[ -n $(plugin_read_config WORKDIR) ]] && [[ $(plugin_read_config WORKDIR_CREATE false) == true ]]; then
+  echo "--- :anka: Ensuring $(plugin_read_config WORKDIR) exists"
+  plugin_prompt_and_run anka $ANKA_DEBUG run "$job_image_name" mkdir -p "$(plugin_read_config WORKDIR)"
+fi
+
 ###############################################################
 # Obtain options to pass to bash command on the end of anka run
 bash_ops=()

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,6 +25,8 @@ configuration:
       type: boolean
     workdir:
       type: string
+    workdir-create:
+      type: boolean
     debug:
       type: boolean
     anka-debug:


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

Anka doesn't create the workdir if it doesn't exist and this causes an `-anka: {COMMAND}: command not found` error.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
