### PR TITLE
Add support for Anka Build 2.3 and Big Sur

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ steps:
           vm-name: macos-base-10.14
 ```
 
+## Hook Steps
+
+Hook | Description
+--- | ---
+`pre-checkout` | Download the specified virtual machine from your registry (if applicable).
+`post-checkout` | Clone the virtual machine and perform any hardware modifications.
+`pre-command` | Run any of your `pre-commands` (see below).
+`command` | Execute your command inside of the cloned virtual machine.
+`post-command` | Run any of your `post-commands` (see below).
+`pre-exit` | Perform any clean up steps
+
 ## Configuration
 
 ### `vm-name` (required)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ A [Buildkite plugin](https://buildkite.com/docs/agent/v3/plugins) for running pi
 - The plugin will create a cloned VM to run instructions in and will delete the VM on pipeline status `cancellation`, `failure`, or `success`.
 - The plugin does not automatically mount the `buildkite-agent` or inject any `BUILDKITE_` environment variables.
 - A lock file (`/tmp/anka-buildkite-plugin-lock`) is created around pull and cloning. This prevents collision/ram state corruption when you're running two different jobs and pulling two different tags on the same anka node. The error you'd see otherwise is `state_lib/b026f71c-7675-11e9-8883-f01898ec0a5d.ank: failed to open image, error 2`
+- If we are unable to detect the FUSE driver within your VM, we will use the `anka cp` utility to copy the contents of your `volume` (or current working directory) into the VM (unless `no-volume` is `true`).
+
+> We recommend using Anka Build 2.3 or greater with this plugin, especially if you have Big Sur VMs.
 
 ## Anka VM Template & Tag Requirements
 
@@ -86,7 +89,7 @@ steps:
 
 ### `volume` (optional)
 
-The path to a directory, other than the current directory, you wish to mount into the Anka VM.
+The path to a directory on your Buildkite host you wish to mount into the Anka VM. Defaults to the current working directory. Mounted volume will be available within the VM at `/private/var/tmp/ankafs.0`.
 
 Example: `/some/directory`
 
@@ -104,7 +107,7 @@ Example: `true`
 
 ### `workdir` (optional)
 
-The fully-qualified path of the working directory inside the Anka VM.
+The fully-qualified path of the working directory inside the Anka VM. Defaults to `/private/var/tmp/ankafs.0` unless `no-volume` is set to true.
 
 Example: `/some/directory`
 

--- a/hooks/command
+++ b/hooks/command
@@ -3,157 +3,94 @@ set -euo pipefail
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$DIR/../lib/shared.bash"
 
-job_image_name="$(plugin_read_config VM_NAME)-$BUILDKITE_JOB_ID"
+job_image_name="$(plugin_read_config VM_NAME)-${BUILDKITE_JOB_ID}"
 
-########################################
-# PRE (anka run) host command execution
-BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS=$(plugin_read_list PRE_COMMANDS)
-if [[ -n "${BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS}" ]]; then
-  host_commands=()
-  while IFS='' read -r line; do host_commands+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS"
-  for command in "${host_commands[@]:+${host_commands[@]}}"; do
-    echo "--- :anka: Executing ${command} on host"
-    if [[ $(plugin_read_config DEBUG "false") =~ (true|on|1) ]] ; then
-      echo -ne '\033[90m$\033[0m' >&2
-      printf " %q" "eval \"$command\"" >&2
-      echo >&2
-    fi
-    # shellcheck disable=SC2086
-    eval "$command"
-  done
+##########################
+# FUSE compatability logic
+# This is compat logic to handle when Veertu's FUSE driver is not installed (if we want to mount a volume)
+if [[ $(plugin_read_config NO_VOLUME false) == false ]]; then
+  echo "--- :anka: Detecting FUSE compatability"
+  # shellcheck disable=SC2086
+  if plugin_prompt_and_run anka run "$job_image_name" kextstat | grep "com.veertu.filesystems.vtufs" &>/dev/null; then
+    echo "Veertu FUSE driver detected. Will mount volume into ${job_image_name}."
+  else
+    echo "Veertu FUSE driver NOT detected."
+    echo "Copying files from $(plugin_read_config VOLUME .) to ${job_image_name}. (This may take awhile depending on the size of your volume)"
+    plugin_prompt_and_run anka $ANKA_DEBUG cp -a "$(plugin_read_config VOLUME .)" "${job_image_name}:/private/var/tmp/ankafs.0"
+  fi
+
+  # Manually assign the workdir to be the ankafs to ensure consistent workdir between FUSE and non-FUSE VMs
+  # shellcheck disable=SC2034
+  BUILDKITE_PLUGIN_ANKA_WORKDIR="$(plugin_read_config WORKDIR /private/var/tmp/ankafs.0)"
 fi
 
-#####################
-# Pull Down the Image
-lock_file enable # If two pulls or a clone and a pull happen on the same host, anka's ram file will get a messed up. Lock file should prevent another pull/clone while one is already happening.
-# shellcheck disable=SC2086
-if ( ! anka $ANKA_DEBUG list "$(plugin_read_config VM_NAME)" ) || [[ $(plugin_read_config ALWAYS_PULL false) =~ (true|on|1|shrink) ]]; then
-  pull_args=()
-  if [[ -n $(plugin_read_config VM_REGISTRY_TAG) ]]; then
-    pull_args+=("--tag" "$(plugin_read_config VM_REGISTRY_TAG)")
-  fi
-  if [[ -n $(plugin_read_config VM_REGISTRY_VERSION) ]]; then
-    pull_args+=("--version" "$(plugin_read_config VM_REGISTRY_VERSION)")
-  fi
-  if [[ $(plugin_read_config ALWAYS_PULL) == "shrink" ]]; then
-    pull_args+=("-s") # Remove other local tags to optimize the footprint
-  fi
-  echo "--- :anka: Pulling $(plugin_read_config VM_NAME) from Anka Registry"
+# Ensure the (user-specified) workdir exists (we ignore our default value for the purposes of this logic)
+# shellcheck disable=SC2086,SC2154,SC2091
+if [[ -n $(plugin_read_config WORKDIR) ]] && [[ $(plugin_read_config WORKDIR_CREATE false) == true ]]; then
+  echo "--- :anka: Ensuring $(plugin_read_config WORKDIR) exists"
   # shellcheck disable=SC2086
-  plugin_prompt_and_run anka $ANKA_DEBUG registry $FAILOVER_REGISTRY pull "${pull_args[@]:+${pull_args[@]}}" "$(plugin_read_config VM_NAME)" # ${pull_args[@]:+${pull_args[@]}}: pull_args[@]: unbound variable : https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
-else
-  echo ":anka: $(plugin_read_config VM_NAME) is already present on the host"
+  plugin_prompt_and_run anka $ANKA_DEBUG run "$job_image_name" mkdir -p "$(plugin_read_config WORKDIR)"
 fi
 
 #######################################
 # Parse out all the run command options
 run_args=()
-# Working directory inside the VM
-if [[ -n $(plugin_read_config WORKDIR) ]] ; then
-  run_args+=("--workdir" "$(plugin_read_config WORKDIR)")
-fi
+
 # Mount host directory (current directory by default)
-if [[ -n $(plugin_read_config VOLUME) ]] ; then
+if [[ -n $(plugin_read_config VOLUME) ]]; then
   run_args+=("--volume" "$(plugin_read_config VOLUME)")
 fi
+
 # Prevent the mounting of the host directory
 # shellcheck disable=SC2091
 if $(plugin_read_config NO_VOLUME false); then
   run_args+=("--no-volume")
 fi
+
 # Inherit environment variables from host
 # shellcheck disable=SC2091
 if $(plugin_read_config INHERIT_ENVIRONMENT_VARS false) ; then
   run_args+=("--env")
 fi
+
 # Provide an environment variable file
 if [[ -n $(plugin_read_config ENVIRONMENT_FILE) ]] ; then
   run_args+=("--env-file" "$(plugin_read_config ENVIRONMENT_FILE)")
 fi
+
 # Wait to start processing until network can be established
 # shellcheck disable=SC2091
 if $(plugin_read_config WAIT_NETWORK false); then
   run_args+=("--wait-network")
 fi
+
 # Wait to start processing until time is updated
 # shellcheck disable=SC2091
 if $(plugin_read_config WAIT_TIME false); then
   run_args+=("--wait-time")
 fi
+
+# Add the workdir if specified
+# shellcheck disable=SC2091
+if [[ -n $(plugin_read_config WORKDIR) ]]; then
+  run_args+=("--workdir" "$(plugin_read_config WORKDIR)")
+fi
+
 run_args+=("$job_image_name")
-#
-echo "--- :anka: Cloning $(plugin_read_config VM_NAME) to $job_image_name"
-# shellcheck disable=SC2086,SC2154
-plugin_prompt_and_run anka $ANKA_DEBUG clone "$(plugin_read_config VM_NAME)" "$job_image_name"
-
-lock_file disable # If two pulls or a clone and a pull happen on the same host, anka's ram file will get a messed up. Lock file should prevent another pull/clone while one is already happening.
-
-#####################################
-# Handle modifications to CPU/RAM/etc
-BUILDKITE_PLUGIN_ANKA_MODIFY_CPU=$(plugin_read_list MODIFY_CPU)
-BUILDKITE_PLUGIN_ANKA_MODIFY_RAM=$(plugin_read_list MODIFY_RAM)
-BUILDKITE_PLUGIN_ANKA_MODIFY_MAC=$(plugin_read_list MODIFY_MAC)
-BUILDKITE_PLUGIN_ANKA_START_DEVICES=$(plugin_read_list START_DEVICES)
-if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_CPU}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_START_DEVICES}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_MAC}" ]]; then
-  echo "--- :anka: Ensuring $job_image_name is stopped"
-  FORCED=${FORCED:-false} # Used for bats triggering of ops
-  stop_ops=()
-  # shellcheck disable=SC2086
-  ( $FORCED || [[ -n "$(anka list $job_image_name \| grep suspended)" ]] ) && stop_ops+=("--force")
-  # shellcheck disable=SC2086
-  plugin_prompt_and_run anka stop "${stop_ops[@]:+${stop_ops[@]}}" $job_image_name
-fi
-acceptable_pattern='^[0-9]+$'
-if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_CPU}" ]]; then
-  [[ ! $BUILDKITE_PLUGIN_ANKA_MODIFY_CPU =~ $acceptable_pattern ]] && echo "Acceptable input: [0-9]+" && exit 1
-  echo "--- :anka: Modifying CPU cores to ${BUILDKITE_PLUGIN_ANKA_MODIFY_CPU}"
-  # shellcheck disable=SC2086
-  plugin_prompt_and_run anka modify $job_image_name set cpu $BUILDKITE_PLUGIN_ANKA_MODIFY_CPU
-fi
-if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}" ]]; then
-  [[ ! $BUILDKITE_PLUGIN_ANKA_MODIFY_RAM =~ $acceptable_pattern ]] && echo "Acceptable input: [0-9]+" && exit 1
-  echo "--- :anka: Modifying RAM to ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G"
-  # shellcheck disable=SC2086
-  plugin_prompt_and_run anka modify $job_image_name set ram ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G
-fi
-acceptable_mac_pattern='^([a-fA-F0-9]{2}:){5}[a-fA-F0-9]{2}$'
-if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_MAC}" ]]; then
-  [[ ! $BUILDKITE_PLUGIN_ANKA_MODIFY_MAC =~ $acceptable_mac_pattern ]] && echo "Acceptable input: $acceptable_mac_pattern" && exit 1
-  echo "--- :anka: Modifying MAC to ${BUILDKITE_PLUGIN_ANKA_MODIFY_MAC}"
-  # shellcheck disable=SC2086
-  plugin_prompt_and_run anka modify $job_image_name set network-card --mac ${BUILDKITE_PLUGIN_ANKA_MODIFY_MAC}
-fi
-if [[ -n "${BUILDKITE_PLUGIN_ANKA_START_DEVICES}" ]]; then
-  start_devices=()
-  while IFS='' read -r line; do start_devices+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_START_DEVICES"
-  option=""
-  for device in "${start_devices[@]:+${start_devices[@]}}"; do
-   option+="-d ${device} "
-  done
-  echo "--- :anka: Starting VM with ${option}"
-  # shellcheck disable=SC2086
-  plugin_prompt_and_run anka start $option $job_image_name
-fi
-
-# Ensure the workdir exists
-# shellcheck disable=SC2086,SC2154,SC2091
-if [[ -n $(plugin_read_config WORKDIR) ]] && [[ $(plugin_read_config WORKDIR_CREATE false) == true ]]; then
-  echo "--- :anka: Ensuring $(plugin_read_config WORKDIR) exists"
-  plugin_prompt_and_run anka $ANKA_DEBUG run "$job_image_name" mkdir -p "$(plugin_read_config WORKDIR)"
-fi
 
 ###############################################################
 # Obtain options to pass to bash command on the end of anka run
 bash_ops=()
+
 # Run bash with -i for interactive (anka run defaults to this off)
 # shellcheck disable=SC2091
 if $(plugin_read_config BASH_INTERACTIVE false); then
   bash_ops+=("-i")
 fi
-bash_ops+=("-c") # Needed, don't remove
+bash_ops+=("-c") # Needed, don't remove or move
 
 ##########
 # ANKA RUN
@@ -165,20 +102,3 @@ for command in "${commands[@]:-}"; do
   plugin_prompt_and_run anka $ANKA_DEBUG run "${run_args[@]:+${run_args[@]}}" bash "${bash_ops[@]:+${bash_ops[@]}}" "$command"
 done
 
-########################################
-# POST (anka run) host command execution
-BUILDKITE_PLUGIN_ANKA_POST_COMMANDS=$(plugin_read_list POST_COMMANDS)
-if [[ -n "${BUILDKITE_PLUGIN_ANKA_POST_COMMANDS}" ]]; then
-  host_commands=()
-  while IFS='' read -r line; do host_commands+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_POST_COMMANDS"
-  for command in "${host_commands[@]:+${host_commands[@]}}"; do
-    echo "--- :anka: Executing ${command} on host"
-    if [[ $(plugin_read_config DEBUG "false") =~ (true|on|1) ]] ; then
-      echo -ne '\033[90m$\033[0m' >&2
-      printf " %q" "eval \"$command\"" >&2
-      echo >&2
-    fi
-    # shellcheck disable=SC2086
-    eval "$command"
-  done
-fi

--- a/hooks/command
+++ b/hooks/command
@@ -14,7 +14,7 @@ job_image_name="$(plugin_read_config VM_NAME)-${BUILDKITE_JOB_ID}"
 if [[ $(plugin_read_config NO_VOLUME false) == false ]]; then
   echo "--- :anka: Detecting FUSE compatability"
   # shellcheck disable=SC2086
-  if plugin_prompt_and_run anka run "$job_image_name" kextstat | grep "com.veertu.filesystems.vtufs" &>/dev/null; then
+  if plugin_prompt_and_run anka run --no-volume "$job_image_name" kextstat | grep "com.veertu.filesystems.vtufs" &>/dev/null; then
     echo "Veertu FUSE driver detected. Will mount volume into ${job_image_name}."
   else
     echo "Veertu FUSE driver NOT detected."

--- a/hooks/post-checkout
+++ b/hooks/post-checkout
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck disable=SC1090,SC1091
+. "$DIR/../lib/shared.bash"
+
+job_image_name="$(plugin_read_config VM_NAME)-${BUILDKITE_JOB_ID}"
+
+echo "--- :anka: Cloning $(plugin_read_config VM_NAME) to $job_image_name"
+# shellcheck disable=SC2086,SC2154
+plugin_prompt_and_run anka $ANKA_DEBUG clone "$(plugin_read_config VM_NAME)" "$job_image_name"
+
+#####################################
+# Handle modifications to CPU/RAM/etc
+BUILDKITE_PLUGIN_ANKA_MODIFY_CPU=$(plugin_read_list MODIFY_CPU)
+BUILDKITE_PLUGIN_ANKA_MODIFY_RAM=$(plugin_read_list MODIFY_RAM)
+BUILDKITE_PLUGIN_ANKA_MODIFY_MAC=$(plugin_read_list MODIFY_MAC)
+BUILDKITE_PLUGIN_ANKA_START_DEVICES=$(plugin_read_list START_DEVICES)
+
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_CPU}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_START_DEVICES}" ]] || [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_MAC}" ]]; then
+  echo "--- :anka: Ensuring $job_image_name is stopped"
+  FORCED=${FORCED:-false} # Used for bats triggering of ops
+  stop_ops=()
+  # shellcheck disable=SC2086
+  ( $FORCED || [[ -n "$(anka list $job_image_name \| grep suspended)" ]] ) && stop_ops+=("--force")
+  # shellcheck disable=SC2086
+  plugin_prompt_and_run anka stop "${stop_ops[@]:+${stop_ops[@]}}" "$job_image_name"
+fi
+
+acceptable_pattern='^[0-9]+$'
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_CPU}" ]]; then
+  [[ ! $BUILDKITE_PLUGIN_ANKA_MODIFY_CPU =~ $acceptable_pattern ]] && echo "Acceptable input: [0-9]+" && exit 1
+  echo "--- :anka: Modifying CPU cores to ${BUILDKITE_PLUGIN_ANKA_MODIFY_CPU}"
+  # shellcheck disable=SC2086
+  plugin_prompt_and_run anka modify $job_image_name set cpu $BUILDKITE_PLUGIN_ANKA_MODIFY_CPU
+fi
+
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}" ]]; then
+  [[ ! $BUILDKITE_PLUGIN_ANKA_MODIFY_RAM =~ $acceptable_pattern ]] && echo "Acceptable input: [0-9]+" && exit 1
+  echo "--- :anka: Modifying RAM to ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G"
+  # shellcheck disable=SC2086
+  plugin_prompt_and_run anka modify $job_image_name set ram ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G
+fi
+
+acceptable_mac_pattern='^([a-fA-F0-9]{2}:){5}[a-fA-F0-9]{2}$'
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_MODIFY_MAC}" ]]; then
+  [[ ! $BUILDKITE_PLUGIN_ANKA_MODIFY_MAC =~ $acceptable_mac_pattern ]] && echo "Acceptable input: $acceptable_mac_pattern" && exit 1
+  echo "--- :anka: Modifying MAC to ${BUILDKITE_PLUGIN_ANKA_MODIFY_MAC}"
+  # shellcheck disable=SC2086
+  plugin_prompt_and_run anka modify $job_image_name set network-card --mac ${BUILDKITE_PLUGIN_ANKA_MODIFY_MAC}
+fi
+
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_START_DEVICES}" ]]; then
+  start_devices=()
+  while IFS='' read -r line; do start_devices+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_START_DEVICES"
+  option=""
+  for device in "${start_devices[@]:+${start_devices[@]}}"; do
+   option+="-d ${device} "
+  done
+  echo "--- :anka: Starting VM with ${option}"
+  # shellcheck disable=SC2086
+  plugin_prompt_and_run anka start $option $job_image_name
+fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck disable=SC1090,SC1091
+. "$DIR/../lib/shared.bash"
+
+BUILDKITE_PLUGIN_ANKA_POST_COMMANDS=$(plugin_read_list POST_COMMANDS)
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_POST_COMMANDS}" ]]; then
+  host_commands=()
+  while IFS='' read -r line; do host_commands+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_POST_COMMANDS"
+  for command in "${host_commands[@]:+${host_commands[@]}}"; do
+    echo "--- :anka: Executing ${command} on host"
+    if [[ $(plugin_read_config DEBUG "false") =~ (true|on|1) ]] ; then
+      echo -ne '\033[90m$\033[0m' >&2
+      printf " %q" "eval \"$command\"" >&2
+      echo >&2
+    fi
+    # shellcheck disable=SC2086
+    eval "$command"
+  done
+fi

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck disable=SC1090,SC1091
+. "$DIR/../lib/shared.bash"
+
+#
+# We run this pre-checkout because if we can not pull down the necessary image, then there is no point checking out the
+# source code since we won't be able to run anything anyways (especially if the git repository is large).
+#
+
+lock_file enable # If two pulls or a clone and a pull happen on the same host, anka's ram file will get a messed up. Lock file should prevent another pull/clone while one is already happening.
+
+# shellcheck disable=SC2086
+if ( ! anka $ANKA_DEBUG list "$(plugin_read_config VM_NAME)" ) || [[ $(plugin_read_config ALWAYS_PULL false) =~ (true|on|1|shrink) ]]; then
+  pull_args=()
+  if [[ -n $(plugin_read_config VM_REGISTRY_TAG) ]]; then
+    pull_args+=("--tag" "$(plugin_read_config VM_REGISTRY_TAG)")
+  fi
+  if [[ -n $(plugin_read_config VM_REGISTRY_VERSION) ]]; then
+    pull_args+=("--version" "$(plugin_read_config VM_REGISTRY_VERSION)")
+  fi
+  if [[ $(plugin_read_config ALWAYS_PULL) == "shrink" ]]; then
+    pull_args+=("-s") # Remove other local tags to optimize the footprint
+  fi
+  echo "--- :anka: Pulling $(plugin_read_config VM_NAME) from Anka Registry"
+  # shellcheck disable=SC2086
+  plugin_prompt_and_run anka $ANKA_DEBUG registry $FAILOVER_REGISTRY pull "${pull_args[@]:+${pull_args[@]}}" "$(plugin_read_config VM_NAME)" # ${pull_args[@]:+${pull_args[@]}}: pull_args[@]: unbound variable : https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u
+else
+  echo ":anka: $(plugin_read_config VM_NAME) is already present on the host"
+fi
+
+lock_file disable # If two pulls or a clone and a pull happen on the same host, anka's ram file will get a messed up. Lock file should prevent another pull/clone while one is already happening.

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
+
+# shellcheck disable=SC1090,SC1091
+. "$DIR/../lib/shared.bash"
+
+BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS=$(plugin_read_list PRE_COMMANDS)
+if [[ -n "${BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS}" ]]; then
+  host_commands=()
+  while IFS='' read -r line; do host_commands+=("$line"); done <<< "$BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS"
+  for command in "${host_commands[@]:+${host_commands[@]}}"; do
+    echo "--- :anka: Executing ${command} on host"
+    if [[ $(plugin_read_config DEBUG "false") =~ (true|on|1) ]] ; then
+      echo -ne '\033[90m$\033[0m' >&2
+      printf " %q" "eval \"$command\"" >&2
+      echo >&2
+    fi
+    # shellcheck disable=SC2086
+    eval "$command"
+  done
+fi
+

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$DIR/../lib/shared.bash"
 
 job_image_name="$(plugin_read_config VM_NAME)-$BUILDKITE_JOB_ID"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -25,7 +25,7 @@ teardown() {
 
 @test "Run BUILDKITE_COMMAND on machine with FUSE" {
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
@@ -36,7 +36,7 @@ teardown() {
 
 @test "Run BUILDKITE_COMMAND on machine without FUSE" {
    stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
     "cp -a . 10.14-UUID:/private/var/tmp/ankafs.0 : " \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
@@ -50,7 +50,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_WORKDIR="/workdir"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --workdir /workdir 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
@@ -65,7 +65,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_WORKDIR="/workdir"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
     "cp -a . 10.14-UUID:/private/var/tmp/ankafs.0 : " \
     "run --workdir /workdir 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
@@ -83,7 +83,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_WORKDIR_CREATE=true
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run 10.14-UUID mkdir -p /workdir : echo 'ran mkdir'" \
     "run --workdir /workdir 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
@@ -100,7 +100,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_VOLUME="volume"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --volume volume --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
@@ -115,7 +115,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_VOLUME="volume"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
     "cp -a volume 10.14-UUID:/private/var/tmp/ankafs.0 : " \
     "run --volume volume --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
@@ -145,7 +145,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_INHERIT_ENVIRONMENT_VARS="true"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --env --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
@@ -160,7 +160,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_ENVIRONMENT_FILE="./env-file"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --env-file ./env-file --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
@@ -175,7 +175,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_WAIT_NETWORK="true"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --wait-network --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
@@ -190,7 +190,7 @@ teardown() {
   export BUILDKITE_PLUGIN_ANKA_WAIT_TIME="true"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --wait-time --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
@@ -209,7 +209,7 @@ teardown() {
 env"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"ls -alht\" : echo 'ran ls command in anka'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"env\" : echo 'ran env command in anka'"
 
@@ -228,7 +228,7 @@ env"
   export BUILDKITE_PLUGIN_ANKA_ANKA_DEBUG=true
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "--debug run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"ls -alht\" : echo 'ran ls command in anka'" \
     "--debug run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"env\" : echo 'ran env command in anka'"
 
@@ -247,7 +247,7 @@ env"
   export BUILDKITE_PLUGIN_ANKA_BASH_INTERACTIVE=true
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -i -c \"ls -alht\" : echo 'ran ls command in anka'" \
 
   run $PWD/hooks/command
@@ -266,7 +266,7 @@ env"
   export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP="5"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"sleep 5; ls -alht\" : echo ran command in anka" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"sleep 5; env\" : echo ran command in anka"
 
@@ -277,7 +277,7 @@ env"
   unset BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"ls -alht\" : echo 'ran command in anka'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"env\" : echo 'ran command in anka'"
 
@@ -294,7 +294,7 @@ env"
   export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP="8.8.8.8"
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"while ! ping -c1 8.8.8.8 | grep -v '\\---'; do sleep 1; done;ls -alht\" : echo 'ran command in anka'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"while ! ping -c1 8.8.8.8 | grep -v '\\---'; do sleep 1; done;env\" : echo r'an command in anka'"
 
@@ -305,7 +305,7 @@ env"
   unset BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP
 
   stub anka \
-    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --no-volume 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"ls -alht\" : echo 'ran command in anka'" \
     "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"env\" : echo 'ran command in anka'"
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -3,319 +3,201 @@
 load '/usr/local/lib/bats/load.bash'
 
 # Uncomment to enable stub debug output:
+# export BATS_MOCK_DETAIL=/dev/tty
 # export ANKA_STUB_DEBUG=/dev/tty
-# export BUILDKITE_PLUGIN_ANKA_DEBUG=true
 
-export BUILDKITE_BUILD_URL="https://buildkite.com/repo/name/builds/12034"
+export KEXSTAT_OUTPUT_PRESENT='120    0 0xffffff7f82aba000 0x17000    0x17000    com.veertu.filesystems.vtufs (3.11.0) 26F3D9BE-3B96-36B1-A2FA-5986EF0ADC2F <8 6 5 3 1>'
+export KEXSTAT_OUTPUT_MISSING="191    0 0xffffff7f847c1000 0x19000    0x19000    com.github.kbfuse.filesystems.kbfuse (3.10.0) E0B603B0-D9BC-33D0-8DE4-58A76DC4990A <8 6 5 3 1>"
 
-@test "Run with BUILDKITE_COMMAND when VM is missing" {
+setup() {
   export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
+  export BUILDKITE_PLUGIN_ANKA_VM_NAME="10.14"
+  export BUILDKITE_COMMAND='command "a string"'
+}
 
+teardown() {
+  unstub anka
+
+  unset BUILDKITE_JOB_ID
+  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
+  unset BUILDKITE_COMMAND
+}
+
+@test "Run BUILDKITE_COMMAND on machine with FUSE" {
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
-
-  unstub anka
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
-@test "Run with BUILDKITE_COMMAND when VM is missing and has tag" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
-  export BUILDKITE_PLUGIN_ANKA_VM_REGISTRY_TAG="my-tag"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull --tag my-tag ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+@test "Run BUILDKITE_COMMAND on machine without FUSE" {
+   stub anka \
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
+    "cp -a . 10.14-UUID:/private/var/tmp/ankafs.0 : " \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_VM_REGISTRY_TAG
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
-
-@test "Run with BUILDKITE_COMMAND when VM is missing and has version" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
-  export BUILDKITE_PLUGIN_ANKA_VM_REGISTRY_VERSION="1"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull --version 1 ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in anka"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_VM_REGISTRY_VERSION
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-}
-
-@test "Run with BUILDKITE_COMMAND when VM is always pulled" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
-  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in anka"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-}
-
-@test "Run with BUILDKITE_COMMAND when VM is always pulled (shrink)" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
-  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="shrink"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "registry pull -s ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "ran command in anka"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-}
-
-@test "Run with BUILDKITE_COMMAND and custom workdir" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
+@test "Run with BUILDKITE_COMMAND on a machine with FUSE and a custom workdir" {
   export BUILDKITE_PLUGIN_ANKA_WORKDIR="/workdir"
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run --workdir /workdir ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --workdir /workdir 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_WORKDIR
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
+@test "Run with BUILDKITE_COMMAND on a machine without FUSE and a custom workdir" {
+  export BUILDKITE_PLUGIN_ANKA_WORKDIR="/workdir"
+
+  stub anka \
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
+    "cp -a . 10.14-UUID:/private/var/tmp/ankafs.0 : " \
+    "run --workdir /workdir 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in anka"
+
+  unset BUILDKITE_PLUGIN_ANKA_WORKDIR
+}
+
+
 @test "Run with BUILDKITE_COMMAND, create the workdir first, then use --workdir" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
   export BUILDKITE_PLUGIN_ANKA_WORKDIR="/workdir"
   export BUILDKITE_PLUGIN_ANKA_WORKDIR_CREATE=true
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} mkdir -p $BUILDKITE_PLUGIN_ANKA_WORKDIR : echo ran mkdir" \
-    "run --workdir $BUILDKITE_PLUGIN_ANKA_WORKDIR ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run 10.14-UUID mkdir -p /workdir : echo 'ran mkdir'" \
+    "run --workdir /workdir 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_WORKDIR
-  unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_ANKA_WORKDIR_CREATE
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
-@test "Run with BUILDKITE_COMMAND and custom host volume" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
+@test "Run with BUILDKITE_COMMAND on machine with FUSE with custom host volume" {
   export BUILDKITE_PLUGIN_ANKA_VOLUME="volume"
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run --volume volume ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --volume volume --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_VOLUME
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
+}
+
+@test "Run with BUILDKITE_COMMAND on machine without FUSE with custom host volume" {
+  export BUILDKITE_PLUGIN_ANKA_VOLUME="volume"
+
+  stub anka \
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_MISSING}'" \
+    "cp -a volume 10.14-UUID:/private/var/tmp/ankafs.0 : " \
+    "run --volume volume --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
+
+  run $PWD/hooks/command
+
+  assert_success
+  assert_output --partial "ran command in anka"
+
+  unset BUILDKITE_PLUGIN_ANKA_VOLUME
 }
 
 @test "Run with BUILDKITE_COMMAND and no volumes" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
   export BUILDKITE_PLUGIN_ANKA_NO_VOLUME="true"
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run --no-volume ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run --no-volume 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_NO_VOLUME
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
 @test "Run with BUILDKITE_COMMAND and env vars from host" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
   export BUILDKITE_PLUGIN_ANKA_INHERIT_ENVIRONMENT_VARS="true"
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run --env ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --env --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_INHERIT_ENVIRONMENT_VARS
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
 @test "Run with BUILDKITE_COMMAND and env vars from file" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
   export BUILDKITE_PLUGIN_ANKA_ENVIRONMENT_FILE="./env-file"
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run --env-file ./env-file ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --env-file ./env-file --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_ENVIRONMENT_FILE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
 @test "Run with BUILDKITE_COMMAND and wait for network" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
   export BUILDKITE_PLUGIN_ANKA_WAIT_NETWORK="true"
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run --wait-network ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --wait-network --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_WAIT_NETWORK
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
 @test "Run with BUILDKITE_COMMAND and wait for time" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command \\\"a string\\\""
   export BUILDKITE_PLUGIN_ANKA_WAIT_TIME="true"
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 1" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run --wait-time ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --wait-time --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c 'command \"a string\"' : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_WAIT_TIME
   unset BUILDKITE_COMMAND
   unset BUILDKITE_PLUGIN_ANKA_VM_NAME
@@ -323,16 +205,13 @@ export BUILDKITE_BUILD_URL="https://buildkite.com/repo/name/builds/12034"
 }
 
 @test "Run with BUILDKITE_COMMAND as yaml command list" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
   export BUILDKITE_COMMAND="ls -alht
 env"
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ran ls command in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"env\" : echo ran env command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"ls -alht\" : echo 'ran ls command in anka'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"env\" : echo 'ran env command in anka'"
 
   run $PWD/hooks/command
 
@@ -340,482 +219,99 @@ env"
   assert_output --partial "ran ls command in anka"
   assert_output --partial "ran env command in anka"
 
-  unstub anka
   unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
 }
 
 @test "Run with BUILDKITE_COMMAND with anka-debug" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
   export BUILDKITE_COMMAND="ls -alht
 env"
   export BUILDKITE_PLUGIN_ANKA_ANKA_DEBUG=true
 
   stub anka \
-    "--debug list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "--debug clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "--debug run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ran ls command in anka" \
-    "--debug run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"env\" : echo ran env command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "--debug run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"ls -alht\" : echo 'ran ls command in anka'" \
+    "--debug run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"env\" : echo 'ran env command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
-  assert_output --partial "cloned vm in anka"
   assert_output --partial "ran ls command in anka"
   assert_output --partial "ran env command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_ANKA_DEBUG
   unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-@test "Run with PRE_COMMANDS (yaml list)" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS="echo 123 && echo 456
-echo got 123 && echo \" got 456 \"
-buildkite-agent artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 1 Build\"
-buildkite-agent artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 2 Build\""
-
-  stub buildkite-agent \
-    'artifact download "build.tar.gz" . --step ":aws: Amazon Linux 1 Build" : echo downloaded artifact 1' \
-    'artifact download "build.tar.gz" . --step ":aws: Amazon Linux 2 Build" : echo downloaded artifact 2'
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ran ls command in anka" \
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "123"
-  assert_output --partial "456"
-  assert_output --partial "got 123"
-  assert_output --partial " got 456"
-  assert_output --partial "downloaded artifact 1"
-  assert_output --partial "downloaded artifact 2"
-  assert_output --partial "cloned vm in anka"
-  assert_output --partial "ran ls command in anka"
-
-  unstub anka
-  unstub buildkite-agent
-  unset BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-@test "Run with START_DEVICES (yaml list)" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_START_DEVICES="iphone1
-iphone2"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm" \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} | grep suspended : exit 0" \
-    "stop ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo stopped" \
-    "start -d iphone1 -d iphone2 ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo started with devices" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ran ls command in anka" \
-    
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "cloned vm"
-  assert_output --partial "stopped"
-  assert_output --partial "started with devices"
-  assert_output --partial "ran ls command in anka"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_START_DEVICES
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-
-@test "Run with POST_COMMANDS (yaml list)" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_POST_COMMANDS="echo 123 && echo 456
-echo got 123 && echo \" got 456 \"
-buildkite-agent artifact upload \"build.tar.gz\"
-buildkite-agent artifact upload \"build.tar.gz\""
-
-  stub buildkite-agent \
-    'artifact upload "build.tar.gz" : echo upload artifact 1' \
-    'artifact upload "build.tar.gz" : echo upload artifact 2'
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ran ls command in anka" \
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "123"
-  assert_output --partial "456"
-  assert_output --partial "got 123"
-  assert_output --partial " got 456"
-  assert_output --partial "upload artifact 1"
-  assert_output --partial "upload artifact 2"
-  assert_output --partial "cloned vm in anka"
-  assert_output --partial "ran ls command in anka"
-
-  unstub anka
-  unstub buildkite-agent
-  unset BUILDKITE_PLUGIN_ANKA_POST_COMMANDS
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
 }
 
 @test "Run with bash ops" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
   export BUILDKITE_COMMAND="ls -alht"
   export BUILDKITE_PLUGIN_ANKA_BASH_INTERACTIVE=true
 
   stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -i -c \"ls -alht\" : echo ran ls command in anka" \
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -i -c \"ls -alht\" : echo 'ran ls command in anka'" \
 
   run $PWD/hooks/command
 
   assert_success
   assert_output --partial "ran ls command in anka"
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_BASH_INTERACTIVE
   unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-
-@test "Run with registry-failover" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command"
-  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
-  export BUILDKITE_PLUGIN_ANKA_FAILOVER_REGISTRIES='registry_1
-registry_2
-registry_3'
-
-  stub anka \
-    "registry list : echo -" \
-    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
-    "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
-    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
-
-  run $PWD/hooks/command
-
-  assert_success
-
-  unstub anka
-
-  stub anka \
-    "registry list : exit 30" \
-    "registry list-repos -d : echo '| id     | registry_1  |'" \
-    "registry -r registry_2 list : echo -" \
-    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
-    "registry -r registry_2 pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
-    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
-
-  run $PWD/hooks/command
-
-  assert_success
-
-  unstub anka
-
-  stub anka \
-    "registry list : exit 30" \
-    "registry list-repos -d : echo '| id     | registry_1  |'" \
-    "registry -r registry_2 list : exit 30" \
-    "registry -r registry_3 list : echo -" \
-    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
-    "registry -r registry_3 pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
-    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
-
-  run $PWD/hooks/command
-
-  assert_success
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_FAILOVER_REGISTRIES
 }
 
 @test "Run with pre-execute-sleep" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
   export BUILDKITE_COMMAND="ls -alht
 env"
   export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
   export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP="5"
 
   stub anka \
-    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
-    "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
-    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"sleep ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP}; ls -alht\" : echo ran command in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"sleep ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP}; env\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"sleep 5; ls -alht\" : echo ran command in anka" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"sleep 5; env\" : echo ran command in anka"
 
   run $PWD/hooks/command
 
   assert_success
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_SLEEP
 
   stub anka \
-    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
-    "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
-    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ran command in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"env\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"ls -alht\" : echo 'ran command in anka'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"env\" : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
 
-  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
   unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
 @test "Run with pre-execute-ping-sleep" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
   export BUILDKITE_COMMAND="ls -alht
 env"
-  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
   export BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP="8.8.8.8"
 
   stub anka \
-    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
-    "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
-    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"while ! ping -c1 ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP} | grep -v '\\---'; do sleep 1; done;ls -alht\" : echo ran command in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"while ! ping -c1 ${BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP} | grep -v '\\---'; do sleep 1; done;env\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"while ! ping -c1 8.8.8.8 | grep -v '\\---'; do sleep 1; done;ls -alht\" : echo 'ran command in anka'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"while ! ping -c1 8.8.8.8 | grep -v '\\---'; do sleep 1; done;env\" : echo r'an command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
 
-  unstub anka
   unset BUILDKITE_PLUGIN_ANKA_PRE_EXECUTE_PING_SLEEP
 
   stub anka \
-    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
-    "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo pulled vm in anka" \
-    "clone $BUILDKITE_PLUGIN_ANKA_VM_NAME ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ran command in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"env\" : echo ran command in anka"
+    "run 10.14-UUID kextstat : echo '${KEXSTAT_OUTPUT_PRESENT}'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"ls -alht\" : echo 'ran command in anka'" \
+    "run --workdir /private/var/tmp/ankafs.0 10.14-UUID bash -c \"env\" : echo 'ran command in anka'"
 
   run $PWD/hooks/command
 
   assert_success
 
-  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
   unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-}
-
-
-@test "Modify" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_MODIFY_CPU="6"
-  export BUILDKITE_PLUGIN_ANKA_MODIFY_RAM="32"
-  export BUILDKITE_PLUGIN_ANKA_MODIFY_MAC="00:1B:44:11:3A:B7"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm" \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} | grep suspended : exit 0" \
-    "stop ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo stopped" \
-    "modify ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} set cpu $BUILDKITE_PLUGIN_ANKA_MODIFY_CPU : echo set cpu $BUILDKITE_PLUGIN_ANKA_MODIFY_CPU" \
-    "modify ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} set ram ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G : echo set ram ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G" \
-    "modify ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} set network-card --mac $BUILDKITE_PLUGIN_ANKA_MODIFY_MAC : echo set network-card mac address to $BUILDKITE_PLUGIN_ANKA_MODIFY_MAC" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ls command run"
-
-  run $PWD/hooks/command
-  assert_success
-  assert_output --partial "cloned vm"
-  assert_output --partial "stopped"
-  assert_output --partial "set cpu $BUILDKITE_PLUGIN_ANKA_MODIFY_CPU"
-  assert_output --partial "set ram ${BUILDKITE_PLUGIN_ANKA_MODIFY_RAM}G"
-  assert_output --partial "set network-card mac address to $BUILDKITE_PLUGIN_ANKA_MODIFY_MAC"
-  assert_output --partial "ls command"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_MODIFY_MAC
-  unset BUILDKITE_PLUGIN_ANKA_MODIFY_RAM
-  unset BUILDKITE_PLUGIN_ANKA_MODIFY_CPU
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-@test "Modify CPU Failure" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_MODIFY_CPU="t"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm" \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} | grep suspended : exit 0" \
-    "stop ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo stopped"
-    
-  run $PWD/hooks/command
-  assert_failure
-  assert_output --partial "cloned vm"
-  assert_output --partial "stopped"
-  assert_output --partial "Acceptable input"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_MODIFY_CPU
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-@test "Modify RAM Failure" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_MODIFY_RAM="t"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm" \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} | grep suspended : exit 0" \
-    "stop ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo stopped"
-    
-  run $PWD/hooks/command
-  assert_failure
-  assert_output --partial "cloned vm"
-  assert_output --partial "stopped"
-  assert_output --partial "Acceptable input"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_MODIFY_RAM
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-@test "Modify MAC Failure" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_MODIFY_MAC="192.14"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm" \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} | grep suspended : exit 0" \
-    "stop ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo stopped"
-    
-  run $PWD/hooks/command
-  assert_failure
-  assert_output --partial "cloned vm"
-  assert_output --partial "stopped"
-  assert_output --partial "Acceptable input"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_MODIFY_MAC
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-@test "Modify --force" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-  export BUILDKITE_PLUGIN_ANKA_MODIFY_CPU="6"
-  export BUILDKITE_PLUGIN_ANKA_MODIFY_RAM="32"
-  export FORCED=true
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm" \
-    "stop --force ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo stopped" \
-    "modify ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} set cpu 6 : echo set cpu 6" \
-    "modify ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} set ram 32G : echo set ram 32" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"ls -alht\" : echo ls command run"
-
-  run $PWD/hooks/command
-  assert_output --partial "stopped"
-
-  unstub anka
-  unset BUILDKITE_PLUGIN_ANKA_MODIFY_RAM
-  unset BUILDKITE_PLUGIN_ANKA_MODIFY_CPU
-  unset BUILDKITE_PLUGIN_ANKA_BASH_INTERACTIVE
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
-  unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-}
-
-
-@test "Lock file is created and deleted" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="command"
-  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
-  export LOCK_FILE="/tmp/anka-buildkite-plugin-lock"
-
-  stub anka \
-    "list ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : exit 0" \
-    "registry pull ${BUILDKITE_PLUGIN_ANKA_VM_NAME} : echo pulled vm in anka" \
-    "clone ${BUILDKITE_PLUGIN_ANKA_VM_NAME} ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo cloned vm in anka" \
-    "run ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} bash -c \"$BUILDKITE_COMMAND\" : echo ran command in anka"
-
-  run $PWD/hooks/command
-
-  assert_success
-  assert_output --partial "Created ${LOCK_FILE}"
-  assert_output --partial "Deleted ${LOCK_FILE}"
-
-  unstub anka
-  unset LOCK_FILE
-  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }

--- a/tests/post-checkout.bats
+++ b/tests/post-checkout.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment to enable stub debug output:
+# export ANKA_STUB_DEBUG=/dev/tty
+
+setup() {
+  export BUILDKITE_JOB_ID="UUID"
+  export BUILDKITE_PLUGIN_ANKA_VM_NAME="10.14"
+}
+
+teardown() {
+  unstub anka
+
+  unset BUILDKITE_JOB_ID
+  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
+}
+
+@test "Run with START_DEVICES (yaml list)" {
+  export BUILDKITE_PLUGIN_ANKA_START_DEVICES="iphone1
+iphone2"
+
+  stub anka \
+    "clone 10.14 10.14-UUID : echo 'cloned vm'" \
+    "list 10.14-UUID | grep suspended : exit 0" \
+    "stop 10.14-UUID : echo 'stopped'" \
+    "start -d iphone1 -d iphone2 10.14-UUID : echo 'started with devices'"
+
+  run $PWD/hooks/post-checkout
+
+  assert_success
+  assert_output --partial "cloned vm"
+  assert_output --partial "stopped"
+  assert_output --partial "started with devices"
+
+  unset BUILDKITE_PLUGIN_ANKA_START_DEVICES
+}
+
+@test "Modify" {
+  export BUILDKITE_PLUGIN_ANKA_MODIFY_CPU="6"
+  export BUILDKITE_PLUGIN_ANKA_MODIFY_RAM="32"
+  export BUILDKITE_PLUGIN_ANKA_MODIFY_MAC="00:1B:44:11:3A:B7"
+
+  stub anka \
+    "clone 10.14 10.14-UUID : echo 'cloned vm'" \
+    "list 10.14-UUID | grep suspended : exit 0" \
+    "stop 10.14-UUID : echo 'stopped'" \
+    "modify 10.14-UUID set cpu 6 : echo 'set cpu 6'" \
+    "modify 10.14-UUID set ram 32G : echo 'set ram 32G'" \
+    "modify 10.14-UUID set network-card --mac 00:1B:44:11:3A:B7 : echo 'set network-card mac address to 00:1B:44:11:3A:B7'"
+
+  run $PWD/hooks/post-checkout
+
+  assert_success
+  assert_output --partial "cloned vm"
+  assert_output --partial "stopped"
+  assert_output --partial "set cpu 6"
+  assert_output --partial "set ram 32G"
+  assert_output --partial "set network-card mac address to 00:1B:44:11:3A:B7"
+
+  unset BUILDKITE_PLUGIN_ANKA_MODIFY_MAC
+  unset BUILDKITE_PLUGIN_ANKA_MODIFY_RAM
+  unset BUILDKITE_PLUGIN_ANKA_MODIFY_CPU
+}
+
+@test "Modify CPU Failure" {
+  export BUILDKITE_PLUGIN_ANKA_MODIFY_CPU="t"
+
+  stub anka \
+    "clone 10.14 10.14-UUID : echo 'cloned vm'" \
+    "list 10.14-UUID | grep suspended : exit 0" \
+    "stop 10.14-UUID : echo 'stopped'"
+
+  run $PWD/hooks/post-checkout
+
+  assert_failure
+  assert_output --partial "cloned vm"
+  assert_output --partial "stopped"
+  assert_output --partial "Acceptable input"
+
+  unset BUILDKITE_PLUGIN_ANKA_MODIFY_CPU
+}
+
+@test "Modify RAM Failure" {
+  export BUILDKITE_PLUGIN_ANKA_MODIFY_RAM="t"
+
+  stub anka \
+    "clone 10.14 10.14-UUID : echo 'cloned vm'" \
+    "list 10.14-UUID | grep suspended : exit 0" \
+    "stop 10.14-UUID : echo 'stopped'"
+
+  run $PWD/hooks/post-checkout
+
+  assert_failure
+  assert_output --partial "cloned vm"
+  assert_output --partial "stopped"
+  assert_output --partial "Acceptable input"
+
+  unset BUILDKITE_PLUGIN_ANKA_MODIFY_RAM
+}
+
+@test "Modify MAC Failure" {
+  export BUILDKITE_PLUGIN_ANKA_MODIFY_MAC="192.14"
+
+  stub anka \
+    "clone 10.14 10.14-UUID : echo 'cloned vm'" \
+    "list 10.14-UUID | grep suspended : exit 0" \
+    "stop 10.14-UUID : echo 'stopped'"
+
+  run $PWD/hooks/post-checkout
+
+  assert_failure
+  assert_output --partial "cloned vm"
+  assert_output --partial "stopped"
+  assert_output --partial "Acceptable input"
+
+  unset BUILDKITE_PLUGIN_ANKA_MODIFY_MAC
+}
+
+@test "Modify --force" {
+  export BUILDKITE_PLUGIN_ANKA_MODIFY_CPU="6"
+  export BUILDKITE_PLUGIN_ANKA_MODIFY_RAM="32"
+  export FORCED=true
+
+  stub anka \
+    "clone 10.14 10.14-UUID : echo 'cloned vm'" \
+    "stop --force 10.14-UUID : echo 'stopped'" \
+    "modify 10.14-UUID set cpu 6 : echo 'set cpu 6'" \
+    "modify 10.14-UUID set ram 32G : echo 'set ram 32'"
+
+  run $PWD/hooks/post-checkout
+
+  assert_output --partial "stopped"
+
+  unset BUILDKITE_PLUGIN_ANKA_MODIFY_RAM
+  unset BUILDKITE_PLUGIN_ANKA_MODIFY_CPU
+  unset FORCED
+}

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment to enable stub debug output:
+# export BUILDKITE_PLUGIN_ANKA_DEBUG=true
+
+@test "Execute POST_COMMANDS (yaml list)" {
+  export BUILDKITE_PLUGIN_ANKA_POST_COMMANDS="echo 123 && echo 456
+echo got 123 && echo \" got 456 \"
+buildkite-agent artifact upload \"build.tar.gz\"
+buildkite-agent artifact upload \"build.tar.gz\""
+
+  stub buildkite-agent \
+    'artifact upload "build.tar.gz" : echo "upload artifact 1"' \
+    'artifact upload "build.tar.gz" : echo "upload artifact 2"'
+
+  run $PWD/hooks/post-command
+
+  assert_success
+  assert_output --partial "123"
+  assert_output --partial "456"
+  assert_output --partial "got 123"
+  assert_output --partial " got 456"
+  assert_output --partial "upload artifact 1"
+  assert_output --partial "upload artifact 2"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ANKA_POST_COMMANDS
+}

--- a/tests/pre-checkout.bats
+++ b/tests/pre-checkout.bats
@@ -1,0 +1,148 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment to enable stub debug output:
+# export ANKA_STUB_DEBUG=/dev/tty
+
+setup() {
+  export BUILDKITE_BUILD_URL="https://buildkite.com/repo/name/builds/12034"
+  export BUILDKITE_PLUGIN_ANKA_VM_NAME="10.14"
+}
+
+teardown() {
+  unstub anka
+  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
+}
+
+@test "Pulls down VM when VM is missing" {
+  stub anka \
+    "list 10.14 : exit 1" \
+    "registry pull 10.14 : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+  assert_output --partial "pulled vm in anka"
+}
+
+@test "Pulls down VM when VM is missing and has tag" {
+  export BUILDKITE_PLUGIN_ANKA_VM_REGISTRY_TAG="my-tag"
+
+  stub anka \
+    "list 10.14 : exit 1" \
+    "registry pull --tag my-tag 10.14 : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+  assert_output --partial "pulled vm in anka"
+
+  unset BUILDKITE_PLUGIN_ANKA_VM_REGISTRY_TAG
+}
+
+
+@test "Pulls down VM when VM is missing and has version" {
+  export BUILDKITE_PLUGIN_ANKA_VM_REGISTRY_VERSION="1"
+
+  stub anka \
+    "list 10.14 : exit 1" \
+    "registry pull --version 1 10.14 : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+  assert_output --partial "pulled vm in anka"
+
+  unset BUILDKITE_PLUGIN_ANKA_VM_REGISTRY_VERSION
+}
+
+@test "Pulls down VM when VM is always pulled" {
+  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
+
+  stub anka \
+    "list 10.14 : exit 0" \
+    "registry pull 10.14 : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+  assert_output --partial "pulled vm in anka"
+
+  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
+}
+
+@test "Pulls down VM when VM is always pulled (shrink)" {
+  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="shrink"
+
+  stub anka \
+    "list 10.14 : exit 0" \
+    "registry pull -s 10.14 : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+  assert_output --partial "pulled vm in anka"
+
+  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
+}
+
+@test "Lock file is created and deleted" {
+  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
+  export LOCK_FILE="/tmp/anka-buildkite-plugin-lock"
+
+  stub anka \
+    "list 10.14 : exit 0" \
+    "registry pull 10.14 : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+  assert_output --partial "Created ${LOCK_FILE}"
+  assert_output --partial "Deleted ${LOCK_FILE}"
+
+  unset LOCK_FILE
+  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
+}
+
+@test "Run with registry-failover" {
+  export BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL="true"
+  export BUILDKITE_PLUGIN_ANKA_FAILOVER_REGISTRIES='registry_1
+registry_2
+registry_3'
+
+  stub anka \
+    "registry list : echo -" \
+    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
+    "registry pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+
+  stub anka \
+    "registry list : exit 30" \
+    "registry list-repos -d : echo '| id     | registry_1  |'" \
+    "registry -r registry_2 list : echo -" \
+    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
+    "registry -r registry_2 pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+
+  stub anka \
+    "registry list : exit 30" \
+    "registry list-repos -d : echo '| id     | registry_1  |'" \
+    "registry -r registry_2 list : exit 30" \
+    "registry -r registry_3 list : echo -" \
+    "list $BUILDKITE_PLUGIN_ANKA_VM_NAME : exit 0" \
+    "registry -r registry_3 pull $BUILDKITE_PLUGIN_ANKA_VM_NAME : echo 'pulled vm in anka'"
+
+  run $PWD/hooks/pre-checkout
+
+  assert_success
+
+  unset BUILDKITE_PLUGIN_ANKA_ALWAYS_PULL
+  unset BUILDKITE_PLUGIN_ANKA_FAILOVER_REGISTRIES
+}

--- a/tests/pre-command.bats
+++ b/tests/pre-command.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load '/usr/local/lib/bats/load.bash'
+
+# Uncomment to enable stub debug output:
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+
+@test "Execute with PRE_COMMANDS (yaml list)" {
+  export BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS="echo 123 && echo 456
+echo got 123 && echo \" got 456 \"
+buildkite-agent artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 1 Build\"
+buildkite-agent artifact download \"build.tar.gz\" . --step \":aws: Amazon Linux 2 Build\""
+
+  stub buildkite-agent \
+    'artifact download "build.tar.gz" . --step ":aws: Amazon Linux 1 Build" : echo "downloaded artifact 1"' \
+    'artifact download "build.tar.gz" . --step ":aws: Amazon Linux 2 Build" : echo "downloaded artifact 2"'
+
+  run $PWD/hooks/pre-command
+
+  assert_success
+  assert_output --partial "123"
+  assert_output --partial "456"
+  assert_output --partial "got 123"
+  assert_output --partial " got 456"
+  assert_output --partial "downloaded artifact 1"
+  assert_output --partial "downloaded artifact 2"
+
+  unstub buildkite-agent
+  unset BUILDKITE_PLUGIN_ANKA_PRE_COMMANDS
+}

--- a/tests/pre-exit.bats
+++ b/tests/pre-exit.bats
@@ -5,65 +5,49 @@ load '/usr/local/lib/bats/load.bash'
 # Uncomment to enable stub debug output:
 # export ANKA_STUB_DEBUG=/dev/tty
 
+setup() {
+  export BUILDKITE_JOB_ID="UUID"
+  export BUILDKITE_PLUGIN_ANKA_VM_NAME="10.14"
+}
+
+teardown() {
+  unstub anka
+  unset BUILDKITE_JOB_ID
+  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
+}
 
 @test "Cleanup of lock file" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-
   stub anka \
-    "delete --yes ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo deleted vm in anka"
-    
+    "delete --yes 10.14-UUID : echo 'deleted vm in anka'"
+
   touch /tmp/anka-buildkite-plugin-lock
 
   run $PWD/hooks/pre-exit
 
   assert_success
   assert_output --partial "Deleted /tmp/anka-buildkite-plugin-lock"
-
-  unstub anka
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
 @test "Cleanup pre-exit runs properly (delete)" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
-
   stub anka \
-    "delete --yes ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo deleted vm in anka"
+    "delete --yes 10.14-UUID : echo 'deleted vm in anka'"
 
   run $PWD/hooks/pre-exit
 
   assert_success
   assert_output --partial "deleted vm in anka"
-
-  unstub anka
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
 }
 
 @test "Cleanup pre-exit runs properly (suspend)" {
-  export BUILDKITE_JOB_ID="UUID"
-  export BUILDKITE_PLUGIN_ANKA_VM_NAME="macos-base-10.14"
-  export BUILDKITE_COMMAND="ls -alht"
   export BUILDKITE_PLUGIN_ANKA_CLEANUP=false
 
   stub anka \
-    "suspend ${BUILDKITE_PLUGIN_ANKA_VM_NAME}-${BUILDKITE_JOB_ID} : echo suspended vm in anka"
+    "suspend 10.14-UUID : echo 'suspended vm in anka'"
 
   run $PWD/hooks/pre-exit
 
   assert_success
   assert_output --partial "suspended vm in anka"
 
-  unstub anka
-  unset BUILDKITE_COMMAND
-  unset BUILDKITE_PLUGIN_ANKA_VM_NAME
-  unset BUILDKITE_JOB_ID
   unset BUILDKITE_PLUGIN_ANKA_CLEANUP
-
 }


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

If we cannot detect the FUSE driver within the VM, we will use the `anka cp` utility to copy the contents of the volume (or current working directory) into the VM at `/private/var/tmp/ankafs.0`. We do this to try and maintain backwards compatibility for jobs that may expect content to exist at that location.

In addition, we have split up the logic that was in just the `command` hook into several other hooks throughout the job lifecycle. This makes it easier to unit test, but also provides some minor benefits in terms of optimizing behavior.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
